### PR TITLE
[Hotfix] Use debug flag

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -26,6 +26,7 @@ import (
 	"github.com/monax/eris-db/logging"
 	"github.com/monax/eris-db/logging/lifecycle"
 	"github.com/monax/eris-db/util"
+	vm "github.com/monax/eris-db/manager/eris-mint/evm"
 
 	"github.com/spf13/cobra"
 )
@@ -160,6 +161,8 @@ func ServeRunner(do *definitions.Do) func(*cobra.Command, []string) {
 			util.Fatalf("Fatal error reading configuration from %s/%s", do.WorkDir,
 				DefaultConfigFilename)
 		}
+
+		vm.SetDebug(do.Debug)
 
 		newCore, err := NewCoreFromDo(do)
 


### PR DESCRIPTION
Noticed the debug flag was not being respected. The EVM debug ought to be handled by the logging system, but this is still pending...