### PR TITLE
Correct for tagged releases (breakage per name change)

### DIFF
--- a/manager/eris-mint/version.go
+++ b/manager/eris-mint/version.go
@@ -28,7 +28,7 @@ const (
 	// Minor version component of the current release
 	erisMintVersionMinor = 16
 	// Patch version component of the current release
-	erisMintVersionPatch = 2
+	erisMintVersionPatch = 1
 )
 
 // Define the compatible consensus engines this application manager

--- a/tests/build_tool.sh
+++ b/tests/build_tool.sh
@@ -23,7 +23,7 @@ IMAGE=quay.io/eris/db
 
 set -e
 
-if [ "$JENKINS_URL" ] || [ "$CIRCLE_BRANCH" ]
+if [ "$JENKINS_URL" ] || [ "$CIRCLE_BRANCH" ] || [ "$CIRCLE_TAG" ]
 then
   REPO=`pwd`
   CI="true"

--- a/version/version.go
+++ b/version/version.go
@@ -32,7 +32,7 @@ const (
 	// Minor version component of the current release
 	erisVersionMinor = 16
 	// Patch version component of the current release
-	erisVersionPatch = 2
+	erisVersionPatch = 1
 )
 
 var erisVersion *VersionIdentifier
@@ -127,4 +127,4 @@ func (version *VersionIdentifier) MatchesMinorVersion(
 
 // IMPORTANT: Eris-DB version must be on the last line of this file for
 // the deployment script tests/build_tool.sh to pick up the right label.
-const VERSION = "0.16.2"
+const VERSION = "0.16.1"


### PR DESCRIPTION
- revert patch version number update on master back to v0.16.1
- correct docker tagging script to run correctly on CircleCi 